### PR TITLE
Add test suite for collect_coins and buy_crate scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 rbr-api-fork
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import sys
+from unittest.mock import MagicMock
+import importlib
+
+mock_rbrapi = MagicMock()
+mock_errors = MagicMock()
+
+class AuthError(Exception):
+    pass
+
+class BonusError(Exception):
+    pass
+
+class LootBoxError(Exception):
+    pass
+
+mock_errors.AuthenticationError = AuthError
+mock_errors.CollectTimedBonusError = BonusError
+mock_errors.LootBoxError = LootBoxError
+mock_rbrapi.errors = mock_errors
+mock_rbrapi.RocketBotRoyale = MagicMock(name='RocketBotRoyale')
+
+sys.modules['rbrapi'] = mock_rbrapi
+sys.modules['rbrapi.errors'] = mock_errors

--- a/tests/test_buy_crate.py
+++ b/tests/test_buy_crate.py
@@ -1,0 +1,96 @@
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestBuyCrate:
+    def test_successful_purchase(self):
+        with patch.dict(os.environ, {"EMAIL": "test@example.com", "PASSWORD": "testpass"}):
+            with patch("sys.argv", ["buy_crate.py"]):
+                with patch("sys.exit"):
+                    with patch("buy_crate.RocketBotRoyale") as mock_client:
+                        mock_client_instance = MagicMock()
+                        mock_client.return_value = mock_client_instance
+                        mock_client_instance.account.return_value.wallet = {"coins": 2000}
+                        
+                        mock_award = MagicMock()
+                        mock_award.award_id = "golden_chest"
+                        mock_client_instance.buy_crate.return_value = mock_award
+                        
+                        from buy_crate import main
+                        main()
+                    
+                    mock_client.assert_called_once_with("test@example.com", "testpass")
+                    mock_client_instance.buy_crate.assert_called_once()
+
+    def test_insufficient_coins(self):
+        with patch.dict(os.environ, {"EMAIL": "test@example.com", "PASSWORD": "testpass"}):
+            with patch("sys.argv", ["buy_crate.py"]):
+                with patch("buy_crate.RocketBotRoyale") as mock_client:
+                    mock_client_instance = MagicMock()
+                    mock_client.return_value = mock_client_instance
+                    mock_client_instance.account.return_value.wallet = {"coins": 500}
+                    
+                    with patch("sys.exit", side_effect=SystemExit(0)):
+                        from buy_crate import main
+                        try:
+                            main()
+                        except SystemExit:
+                            pass
+                    
+                    mock_client_instance.buy_crate.assert_not_called()
+
+    def test_authentication_error(self):
+        exit_mock = MagicMock()
+        with patch.dict(os.environ, {"EMAIL": "test@example.com", "PASSWORD": "testpass"}):
+            with patch("sys.argv", ["buy_crate.py"]):
+                with patch("buy_crate.RocketBotRoyale") as mock_client:
+                    mock_client.side_effect = Exception("Invalid credentials")
+                    
+                    with patch("sys.exit", exit_mock):
+                        from buy_crate import main
+                        try:
+                            main()
+                        except SystemExit:
+                            pass
+                    
+                    mock_client.assert_called_once()
+
+    def test_lootbox_error(self):
+        exit_mock = MagicMock()
+        with patch.dict(os.environ, {"EMAIL": "test@example.com", "PASSWORD": "testpass"}):
+            with patch("sys.argv", ["buy_crate.py"]):
+                with patch("buy_crate.RocketBotRoyale") as mock_client:
+                    mock_client_instance = MagicMock()
+                    mock_client.return_value = mock_client_instance
+                    mock_client_instance.account.return_value.wallet = {"coins": 2000}
+                    mock_client_instance.buy_crate.side_effect = Exception("Out of stock")
+                    
+                    with patch("sys.exit", exit_mock):
+                        from buy_crate import main
+                        try:
+                            main()
+                        except SystemExit:
+                            pass
+                    
+                    mock_client_instance.buy_crate.assert_called_once()
+
+    def test_no_logging_flag(self):
+        with patch.dict(os.environ, {"EMAIL": "test@example.com", "PASSWORD": "testpass"}):
+            with patch("sys.argv", ["buy_crate.py", "--no-logging"]):
+                with patch("sys.exit"):
+                    with patch("buy_crate.RocketBotRoyale") as mock_client:
+                        mock_client_instance = MagicMock()
+                        mock_client.return_value = mock_client_instance
+                        mock_client_instance.account.return_value.wallet = {"coins": 2000}
+                        
+                        mock_award = MagicMock()
+                        mock_award.award_id = "golden_chest"
+                        mock_client_instance.buy_crate.return_value = mock_award
+                        
+                        from buy_crate import main
+                        main()
+                    
+                    mock_client_instance.buy_crate.assert_called_once()

--- a/tests/test_collect_coins.py
+++ b/tests/test_collect_coins.py
@@ -1,0 +1,68 @@
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestCollectCoins:
+    def test_successful_collection(self):
+        with patch.dict(os.environ, {"EMAIL": "test@example.com", "PASSWORD": "testpass"}):
+            with patch("sys.argv", ["collect_coins.py"]):
+                with patch("collect_coins.RocketBotRoyale") as mock_client:
+                    mock_client_instance = MagicMock()
+                    mock_client.return_value = mock_client_instance
+                    mock_client_instance.account.return_value.wallet = {"coins": 500}
+                    
+                    from collect_coins import main
+                    main()
+                
+                mock_client.assert_called_once_with("test@example.com", "testpass")
+                mock_client_instance.collect_timed_bonus.assert_called_once()
+
+    def test_missing_credentials(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("collect_coins.parse_args") as mock_args:
+                mock_args.return_value = MagicMock(email=None, password=None, no_logging=False)
+                
+                from collect_coins import main
+                main()
+                
+                mock_args.assert_called()
+
+    def test_authentication_error(self):
+        with patch.dict(os.environ, {"EMAIL": "test@example.com", "PASSWORD": "testpass"}):
+            with patch("sys.argv", ["collect_coins.py"]):
+                with patch("collect_coins.RocketBotRoyale") as mock_client:
+                    mock_client.side_effect = Exception("Invalid credentials")
+                    
+                    from collect_coins import main
+                    main()
+                
+                mock_client.assert_called_once()
+
+    def test_collect_bonus_error(self):
+        with patch.dict(os.environ, {"EMAIL": "test@example.com", "PASSWORD": "testpass"}):
+            with patch("sys.argv", ["collect_coins.py"]):
+                with patch("collect_coins.RocketBotRoyale") as mock_client:
+                    mock_client_instance = MagicMock()
+                    mock_client.return_value = mock_client_instance
+                    mock_client_instance.collect_timed_bonus.side_effect = Exception("Not available")
+                    
+                    from collect_coins import main
+                    main()
+                
+                mock_client_instance.collect_timed_bonus.assert_called_once()
+
+    def test_no_logging_flag(self):
+        with patch.dict(os.environ, {"EMAIL": "test@example.com", "PASSWORD": "testpass"}):
+            with patch("sys.argv", ["collect_coins.py", "--no-logging"]):
+                with patch("collect_coins.RocketBotRoyale") as mock_client:
+                    mock_client_instance = MagicMock()
+                    mock_client.return_value = mock_client_instance
+                    mock_client_instance.account.return_value.wallet = {"coins": 500}
+                    
+                    from collect_coins import main
+                    main()
+                
+                mock_client_instance.collect_timed_bonus.assert_called_once()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,41 @@
+import logging
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from logger import Logger
+
+
+class TestLogger:
+    def test_info_logs_message(self, caplog):
+        logger = Logger("test")
+        with caplog.at_level(logging.INFO):
+            logger.info("test message")
+        assert "test message" in caplog.text
+        assert "INFO" in caplog.text
+
+    def test_error_logs_message(self, caplog):
+        logger = Logger("test")
+        with caplog.at_level(logging.ERROR):
+            logger.error("error message")
+        assert "error message" in caplog.text
+        assert "ERROR" in caplog.text
+
+    def test_warning_logs_message(self, caplog):
+        logger = Logger("test")
+        with caplog.at_level(logging.WARNING):
+            logger.warning("warning message")
+        assert "warning message" in caplog.text
+        assert "WARNING" in caplog.text
+
+    def test_exception_logs_message_with_traceback(self, caplog):
+        logger = Logger("test")
+        try:
+            raise ValueError("test error")
+        except ValueError:
+            with caplog.at_level(logging.ERROR):
+                logger.exception("exception message")
+        assert "exception message" in caplog.text
+        assert "ValueError" in caplog.text
+        assert "test error" in caplog.text


### PR DESCRIPTION
- Add tests for buy_crate.py: successful purchase, insufficient coins, auth error, lootbox error, and no-logging flag
- Add tests for collect_coins.py: successful collection, missing credentials, auth error, bonus error, and no-logging flag
- Add tests for logger.py: info, error, warning, and exception logging
- Add pytest to requirements.txt