### PR TITLE
Update buy_crate workflow to run 4 times per day

### DIFF
--- a/.github/workflows/buy_crate.yml
+++ b/.github/workflows/buy_crate.yml
@@ -2,7 +2,7 @@ name: Buy crate
 
 on:
   schedule:
-    - cron: "*/120 * * * *"
+    - cron: "0 */6 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Updated cron schedule from `*/120 * * * *` to `0 */6 * * *` to run 4 times per day (midnight, 6am, noon, 6pm UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)